### PR TITLE
Add thumbnail generation for gpt-image-2 action

### DIFF
--- a/src/Action/Definitions/GenerateImage.php
+++ b/src/Action/Definitions/GenerateImage.php
@@ -121,21 +121,39 @@ class GenerateImage extends AbstractActionDefinition {
 			return $this->build_direct_error_response(__( 'Error: Failed to save generated image.', LineConnect::PLUGIN_NAME ));
 		}
 
-		// Check if preview is within LINE's 1MB limit
+		// Check if original image is within LINE's 10MB limit
 		$file_size = strlen($binary);
-		if ($file_size > 1048576) {
-			return $this->build_direct_error_response(__( 'Error: Generated image exceeds 1MB preview size limit for LINE messages.', LineConnect::PLUGIN_NAME ));
+		if ($file_size > 10485760) {
+			return $this->build_direct_error_response(__( 'Error: Generated image exceeds 10MB size limit for LINE messages.', LineConnect::PLUGIN_NAME ));
 		}
 
-		$image_message = Builder::createImageMessage($saved['url'], $saved['url']);
+		// Generate thumbnail
+		$thumb = File::generateThumbnail($saved['full_path']);
+		if (!$thumb) {
+			// Fallback to original if thumbnail generation fails, but check size
+			if ($file_size > 1048576) {
+				return $this->build_direct_error_response(__( 'Error: Failed to generate thumbnail and original image exceeds 1MB preview size limit.', LineConnect::PLUGIN_NAME ));
+			}
+			$preview_url = $saved['url'];
+		} else {
+			// Verify thumbnail size
+			if (filesize($thumb['full_path']) > 1048576) {
+				return $this->build_direct_error_response(__( 'Error: Generated thumbnail exceeds 1MB preview size limit.', LineConnect::PLUGIN_NAME ));
+			}
+			$preview_url = $thumb['url'];
+		}
+
+		$image_message = Builder::createImageMessage($saved['url'], $preview_url);
 
 		return array(
 			'success'        => true,
 			'response_mode'  => 'direct',
 			'messages'       => array($image_message),
 			'data'           => array(
-				'file_path' => $saved['file_path'],
-				'file_url'  => $saved['url'],
+				'file_path'      => $saved['file_path'],
+				'file_url'       => $saved['url'],
+				'thumb_path'     => $thumb ? $thumb['file_path'] : null,
+				'thumb_url'      => $thumb ? $thumb['url'] : null,
 			),
 		);
 	}

--- a/src/Bot/File.php
+++ b/src/Bot/File.php
@@ -330,6 +330,63 @@ class File {
     }
 
     /**
+     * オリジナル画像からサムネイルを生成する
+     *
+     * @param string $original_full_path
+     * @param int $max_edge
+     * @param int $quality
+     * @return array{file_path:string,full_path:string,url:string}|false
+     */
+    public static function generateThumbnail($original_full_path, $max_edge = 1024, $quality = 60) {
+        $editor = wp_get_image_editor($original_full_path);
+        if (is_wp_error($editor)) {
+            return false;
+        }
+
+        $size = $editor->get_size();
+        if (!$size) {
+            return false;
+        }
+
+        $width = $size['width'];
+        $height = $size['height'];
+
+        if ($width > $max_edge || $height > $max_edge) {
+            $editor->resize($max_edge, $max_edge, false);
+        }
+
+        $editor->set_quality($quality);
+
+        $path_info = pathinfo($original_full_path);
+        $thumb_dir = trailingslashit($path_info['dirname']) . 'thumbnails';
+        if (!file_exists($thumb_dir)) {
+            if (!wp_mkdir_p($thumb_dir)) {
+                return false;
+            }
+            // Add index.php for security
+            file_put_contents(trailingslashit($thumb_dir) . 'index.php', '<?php http_response_code(404);');
+        }
+
+        $thumb_filename = $path_info['filename'] . '.jpg';
+        $thumb_full_path = trailingslashit($thumb_dir) . $thumb_filename;
+
+        $saved = $editor->save($thumb_full_path, 'image/jpeg');
+        if (is_wp_error($saved)) {
+            return false;
+        }
+
+        $upload_dir = wp_upload_dir();
+        $relative_path = str_replace(trailingslashit($upload_dir['basedir']), '', $thumb_full_path);
+        $url = trailingslashit($upload_dir['baseurl']) . $relative_path;
+
+        return array(
+            'file_path' => $relative_path,
+            'full_path' => $thumb_full_path,
+            'url'       => $url,
+        );
+    }
+
+    /**
      * 公開用の lineconnect ディレクトリを作成する
      *
      * @param string $relative_dir uploads 配下からの相対パス


### PR DESCRIPTION
This change introduces automatic thumbnail generation for images generated via the `generate_image` action. 

Key improvements:
- **Lightweight Previews:** Every generated image now gets a JPEG thumbnail (max 1024px) stored in a `thumbnails/` subdirectory. This ensures faster loading and compatibility with LINE's preview requirements.
- **Increased Limits:** The original image size limit has been raised from 1MB to 10MB, while the preview (thumbnail) is strictly kept under 1MB.
- **Robustness:** If thumbnail generation fails, the system falls back to using the original image if it's small enough.
- **Security:** New `thumbnails/` directories include an `index.php` to prevent directory listing.

---
*PR created automatically by Jules for task [14153115610414177525](https://jules.google.com/task/14153115610414177525) started by @shipwebdotjp*