### PR TITLE
Refactor image generation, logging, and filesystem security

### DIFF
--- a/src/Action/Definitions/GenerateImage.php
+++ b/src/Action/Definitions/GenerateImage.php
@@ -12,6 +12,8 @@ use Shipweb\LineConnect\Message\LINE\Builder;
  * Definition for the generate_image action.
  */
 class GenerateImage extends AbstractActionDefinition {
+	use ImageGenerationTrait;
+
 	/**
 	 * Returns the action key.
 	 *
@@ -162,13 +164,13 @@ class GenerateImage extends AbstractActionDefinition {
 		}
 
 		$output_spec = $this->resolve_output_spec($data['output_format']);
-		$saved = Image::saveGeneratedImage($this->getSecretPrefix(), $this->getLineUserId(), $binary, $output_spec['mime_type'], $output_spec['extension']);
+		$saved = Image::saveGeneratedImage($this->get_secret_prefix(), $this->get_line_user_id(), $binary, $output_spec['mime_type'], $output_spec['extension']);
 		if (! $saved) {
 			return $this->build_direct_error_response(__( 'Error: Failed to save generated image.', LineConnect::PLUGIN_NAME ));
 		}
 
 		// Generate thumbnail
-		$thumb = Image::generateThumbnail($saved['full_path'], $this->getSecretPrefix(), $this->getLineUserId());
+		$thumb = Image::generateThumbnail($saved['full_path'], $this->get_secret_prefix(), $this->get_line_user_id());
 		if (!$thumb) {
 			// Fallback to original if thumbnail generation fails, but check size
 			if ($file_size > 1048576) {
@@ -206,8 +208,6 @@ class GenerateImage extends AbstractActionDefinition {
 			),
 		);
 	}
-
-	use ImageGenerationTrait;
 
 	/**
 	 * Build the OpenAI image request payload.

--- a/src/Action/Definitions/GenerateImageEdit.php
+++ b/src/Action/Definitions/GenerateImageEdit.php
@@ -8,11 +8,14 @@ use Shipweb\LineConnect\Core\LineConnect;
 use Shipweb\LineConnect\Bot\Media\Image;
 use Shipweb\LineConnect\Message\LINE\Builder;
 use Shipweb\LineConnect\Utilities\FileSystem;
+use Shipweb\LineConnect\Utilities\Logging;
 
 /**
  * Definition for the edit_image action.
  */
 class GenerateImageEdit extends AbstractActionDefinition {
+	use ImageGenerationTrait;
+
 	/**
 	 * Returns the action key.
 	 *
@@ -238,8 +241,8 @@ class GenerateImageEdit extends AbstractActionDefinition {
 			)
 		);
 
-		error_log( 'Responses API endpoint for image edit: ' . $responsesEndpoint );
-		error_log( 'Requesting image edit via Responses API: ' . wp_json_encode( $this->redact_image_data_urls_for_log( $request_body ) ) );
+		Logging::logging_with_redact( array( 'endpoint' => $responsesEndpoint ) );
+		Logging::logging_with_redact( array( 'request' => $request_body ), array( 'result' ) );
 
 		$headers = array(
 			'Authorization: Bearer ' . $apiKey,
@@ -257,7 +260,7 @@ class GenerateImageEdit extends AbstractActionDefinition {
 		$curl_error = curl_errno( $curl ) ? curl_error( $curl ) : null;
 		curl_close( $curl );
 
-		error_log( 'Received response from Responses API image edit: ' . wp_json_encode( $this->redact_image_data_urls_for_log( json_decode( $result, true ) ) ) );
+		Logging::logging_with_redact( array( 'response' => json_decode( $result, true ) ), array( 'result' ) );
 
 		if ( $curl_error ) {
 			return $this->build_direct_error_response( sprintf( __( 'Error: %s', LineConnect::PLUGIN_NAME ), $curl_error ) );
@@ -291,12 +294,12 @@ class GenerateImageEdit extends AbstractActionDefinition {
 		}
 
 		$output_spec = $this->resolve_output_spec( $normalized_format );
-		$saved       = Image::saveGeneratedImage( $this->getSecretPrefix(), $this->getLineUserId(), $binary, $output_spec['mime_type'], $output_spec['extension'] );
+		$saved       = Image::saveGeneratedImage( $this->get_secret_prefix(), $this->get_line_user_id(), $binary, $output_spec['mime_type'], $output_spec['extension'] );
 		if ( ! $saved ) {
 			return $this->build_direct_error_response( __( 'Error: Failed to save edited image.', LineConnect::PLUGIN_NAME ) );
 		}
 
-		$thumb = Image::generateThumbnail( $saved['full_path'], $this->getSecretPrefix(), $this->getLineUserId() );
+		$thumb = Image::generateThumbnail( $saved['full_path'], $this->get_secret_prefix(), $this->get_line_user_id() );
 		if ( ! $thumb ) {
 			if ( $file_size > 1048576 ) {
 				if ( file_exists( $saved['full_path'] ) ) {
@@ -451,24 +454,6 @@ class GenerateImageEdit extends AbstractActionDefinition {
 
 		return 'Unexpected response format from OpenAI.';
 	}
-
-	private function redact_image_data_urls_for_log( array $payload ): array {
-		$walker = function ( &$value, $key ) {
-			if ( ( $key === 'image_url' ) && is_string( $value ) && strpos( $value, 'data:image/' ) === 0 ) {
-				$value = preg_replace( '#^data:image/[^;]+;base64,.*$#', 'data:image/***;base64,[redacted]', $value );
-			}
-			if ( $key == 'result' && is_string( $value ) ) {
-				$value = '(redacted)'; // 画像生成の結果はログに残さない
-			}
-		};
-
-		array_walk_recursive( $payload, $walker );
-
-		return $payload;
-	}
-
-	use ImageGenerationTrait;
-
 
 	/**
 	 * Normalize the requested size.

--- a/src/Action/Traits/ImageGenerationTrait.php
+++ b/src/Action/Traits/ImageGenerationTrait.php
@@ -16,13 +16,17 @@ trait ImageGenerationTrait {
 	 *
 	 * @return string
 	 */
-	private function getSecretPrefix(): string {
-		return isset( $this->secret_prefix ) && ! empty( $this->secret_prefix ) ? $this->secret_prefix : '_none';
+	private function get_secret_prefix(): string {
+		return ! empty( $this->secret_prefix ) ? $this->secret_prefix : '_none';
 	}
 
-	private function getLineUserId(): string {
-		// $this->event->source->userId
-		return isset( $this->event->source->userId ) && ! empty( $this->event->source->userId ) ? $this->event->source->userId : '_unknown';
+	/**
+	 * Get LINE user ID safely.
+	 *
+	 * @return string
+	 */
+	private function get_line_user_id(): string {
+		return ! empty( $this->event->source->userId ) ? $this->event->source->userId : '_unknown';
 	}
 
 	/**

--- a/src/Bot/File.php
+++ b/src/Bot/File.php
@@ -228,9 +228,9 @@ class File {
 				$random = wp_generate_password( 8, false, false );
 			}
 			$file_name = $timestamp . '-' . $random . '.' . ltrim( $file_extention, '.' );
-			// set user directory
-			$user_dir = substr( $userId, 1, 4 );
-			$relative_dir = 'attachments/'.$secret_prefix.'/'. gmdate( 'Y/m' ) . '/' . $user_dir;
+			// set user shard (4-char shard)
+			$user_shard = substr( $userId, 1, 4 );
+			$relative_dir = 'attachments/' . $secret_prefix . '/' . gmdate( 'Y/m' ) . '/' . $user_shard;
 			$target_dir_path = FileSystem::make_lineconnect_dir( $relative_dir );
 			if ( $target_dir_path ) {
 				// make file path

--- a/src/Utilities/FileSystem.php
+++ b/src/Utilities/FileSystem.php
@@ -17,10 +17,18 @@ class FileSystem {
             if (! mkdir($root_dir_path, 0777, true)) {
                 return false;
             }
-            file_put_contents($root_dir_path . '/index.php', '<?php http_response_code(404);');
+            if (file_put_contents($root_dir_path . '/index.php', '<?php http_response_code(404);') === false) {
+                return false;
+            }
         }
         // 既存サーバーの古い deny from all を上書きするため毎回書き込む
-        file_put_contents($root_dir_path . '/.htaccess', 'Options -Indexes');
+        $htaccess_path = $root_dir_path . '/.htaccess';
+        $htaccess_content = 'Options -Indexes';
+        if (! file_exists($htaccess_path) || file_get_contents($htaccess_path) !== $htaccess_content) {
+            if (file_put_contents($htaccess_path, $htaccess_content) === false) {
+                return false;
+            }
+        }
 
         $target_dir_path = $root_dir_path . '/' . $dir_name;
 
@@ -28,10 +36,17 @@ class FileSystem {
             if (! mkdir($target_dir_path, 0777, true)) {
                 return false;
             }
-            file_put_contents($target_dir_path . '/index.php', '<?php http_response_code(404);');
+            if (file_put_contents($target_dir_path . '/index.php', '<?php http_response_code(404);') === false) {
+                return false;
+            }
         }
         // 既存サーバーの古い deny from all を上書きするため毎回書き込む
-        file_put_contents($target_dir_path . '/.htaccess', 'Options -Indexes');
+        $target_htaccess_path = $target_dir_path . '/.htaccess';
+        if (! file_exists($target_htaccess_path) || file_get_contents($target_htaccess_path) !== $htaccess_content) {
+            if (file_put_contents($target_htaccess_path, $htaccess_content) === false) {
+                return false;
+            }
+        }
 
         return $target_dir_path;
     }
@@ -42,9 +57,14 @@ class FileSystem {
      * @return string $file_path ファイルパス
      */
     public static function get_lineconnect_file_path($file_path) {
+        // Defensive check: reject paths containing directory traversal segments
+        if (strpos($file_path, '..') !== false) {
+            return false;
+        }
+
         $upload_dir = \wp_upload_dir();
         $root_dir_path = $upload_dir['basedir'] . '/lineconnect';
-        $full_path = $root_dir_path . '/' . $file_path;
+        $full_path = $root_dir_path . '/' . ltrim($file_path, '/');
         if (file_exists($full_path)) {
             return $full_path;
         } else {
@@ -58,9 +78,14 @@ class FileSystem {
      * @return string|false ファイルの公開URL、存在しない場合は false
      */
     public static function get_lineconnect_file_url($file_path) {
+        // Defensive check: reject paths containing directory traversal segments
+        if (strpos($file_path, '..') !== false) {
+            return false;
+        }
+
         $upload_dir = \wp_upload_dir();
         $root_dir_path = $upload_dir['basedir'] . '/lineconnect';
-        $full_path = $root_dir_path . '/' . $file_path;
+        $full_path = $root_dir_path . '/' . ltrim($file_path, '/');
 
         if (! file_exists($full_path)) {
             return false;

--- a/src/Utilities/Logging.php
+++ b/src/Utilities/Logging.php
@@ -4,19 +4,32 @@ namespace Shipweb\LineConnect\Utilities;
 
 class Logging {
 
-    public static function logging_with_redact(array $payload, array $omit_keys = []): void {
-        $walker = function (&$value, $key) use ($omit_keys) {
-            if (($key === 'image_url') && is_string($value) && strpos($value, 'data:image/') === 0) {
-                $value = preg_replace('#^data:image/[^;]+;base64,.*$#', 'data:image/***;base64,[redacted]', $value);
-            }
-            if (in_array($key, $omit_keys, true) && is_string($value)) {
-                $value = '(redacted)';
-            }
-        };
+	/**
+	 * Log a payload with sensitive image data URLs and specified keys redacted.
+	 *
+	 * Note: array_walk_recursive only processes array elements; objects should be cast
+	 * to arrays or passed as JSON-decoded associative arrays to ensure full redaction.
+	 *
+	 * @param array $payload   The data to log and redact.
+	 * @param array $omit_keys Keys whose values should be replaced with '(redacted)'.
+	 * @return array The redacted payload.
+	 */
+	public static function logging_with_redact( array $payload, array $omit_keys = [] ): array {
+		$walker = function ( &$value, $key ) use ( $omit_keys ) {
+			if ( ( $key === 'image_url' ) && is_string( $value ) && strpos( $value, 'data:image/' ) === 0 ) {
+				$value = preg_replace( '#^data:image/[^;]+;base64,.*$#', 'data:image/***;base64,[redacted]', $value );
+			}
+			if ( in_array( $key, $omit_keys, true ) && is_string( $value ) ) {
+				$value = '(redacted)';
+			}
+		};
 
-        array_walk_recursive($payload, $walker);
+		array_walk_recursive( $payload, $walker );
 
-        error_log(print_r($payload, true));
-        //return $payload;
-    }
+		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+			error_log( print_r( $payload, true ) );
+		}
+
+		return $payload;
+	}
 }

--- a/tests/Action/Definitions/GenerateImageEditTest.php
+++ b/tests/Action/Definitions/GenerateImageEditTest.php
@@ -31,34 +31,6 @@ class GenerateImageEditTest extends WP_UnitTestCase {
 		$this->assertSame('https://myproxy.com/v1/responses', $method->invoke($definition, 'https://myproxy.com/v1/responses'));
 	}
 
-	public function test_redact_image_data_urls_for_log_masks_data_urls() {
-		$definition = new GenerateImageEdit();
-		$method = new ReflectionMethod(GenerateImageEdit::class, 'redact_image_data_urls_for_log');
-
-		$payload = array(
-			'input' => array(
-				array(
-					'role' => 'user',
-					'content' => array(
-						array(
-							'type' => 'input_image',
-							'image_url' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
-						),
-						array(
-							'type' => 'input_text',
-							'text' => 'keep this',
-						),
-					),
-				),
-			),
-		);
-
-		$redacted = $method->invoke($definition, $payload);
-
-		$this->assertSame('data:image/***;base64,[redacted]', $redacted['input'][0]['content'][0]['image_url']);
-		$this->assertSame('keep this', $redacted['input'][0]['content'][1]['text']);
-	}
-
 	public function test_resolve_image_edit_endpoint() {
 		$definition = new GenerateImageEdit();
 		$method = new ReflectionMethod(GenerateImageEdit::class, 'resolve_responses_endpoint');

--- a/tests/util/UtilLoggingTest.php
+++ b/tests/util/UtilLoggingTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Shipweb\LineConnect\Utilities\Logging;
+
+class UtilLoggingTest extends WP_UnitTestCase {
+	public function test_logging_with_redact_masks_data_urls() {
+		$payload = array(
+			'input' => array(
+				array(
+					'role' => 'user',
+					'content' => array(
+						array(
+							'type' => 'input_image',
+							'image_url' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+						),
+						array(
+							'type' => 'input_text',
+							'text' => 'keep this',
+						),
+					),
+				),
+			),
+		);
+
+		$redacted = Logging::logging_with_redact($payload);
+
+		$this->assertSame('data:image/***;base64,[redacted]', $redacted['input'][0]['content'][0]['image_url']);
+		$this->assertSame('keep this', $redacted['input'][0]['content'][1]['text']);
+	}
+
+	public function test_logging_with_redact_masks_omit_keys() {
+		$payload = array(
+			'result' => 'secret_data',
+			'other'  => 'public_data',
+			'nested' => array(
+				'result' => 'nested_secret',
+			),
+		);
+
+		$redacted = Logging::logging_with_redact($payload, array('result'));
+
+		$this->assertSame('(redacted)', $redacted['result']);
+		$this->assertSame('public_data', $redacted['other']);
+		$this->assertSame('(redacted)', $redacted['nested']['result']);
+	}
+}


### PR DESCRIPTION
This PR refactors image generation logic, centralizes logging, and enhances filesystem security.

Key changes:
1. **Trait Refactoring**: Renamed trait methods in `ImageGenerationTrait` to follow snake_case conventions (`get_secret_prefix`, `get_line_user_id`) and moved trait imports to the top of class bodies in `GenerateImage` and `GenerateImageEdit`.
2. **Centralized Logging**: Replaced local redaction logic in `GenerateImageEdit` with `Logging::logging_with_redact`. Updated the logging helper to respect `WP_DEBUG_LOG` and use tab indentation.
3. **Security Enhancements**: 
    - Implemented defensive checks in `FileSystem` utilities to reject paths containing directory traversal segments (`..`).
    - Improved `make_lineconnect_dir` to check `file_put_contents` return values and avoid redundant `.htaccess` writes.
4. **Code Clarity**: Renamed misleading `$user_dir` variable to `$user_shard` in `Bot/File.php` to accurately reflect its role.

---
*PR created automatically by Jules for task [16576233865050899295](https://jules.google.com/task/16576233865050899295) started by @shipwebdotjp*