### PR TITLE
Add usage examples to WP user alternative filter documentation

### DIFF
--- a/document/docs/filter/wp-user-alternative/index.md
+++ b/document/docs/filter/wp-user-alternative/index.md
@@ -31,6 +31,12 @@ These hooks let LINE Connect replace WordPress user-related functions with alter
 
 If you return `true`, `UserProvider` will call the `*_alternative` hooks instead of the normal WordPress user functions.
 
+#### Example
+
+```php
+add_filter('slc_filter_use_alternative_user_provider', '__return_true');
+```
+
 ## Replacement hooks
 
 ### slc_filter_get_userdata
@@ -41,6 +47,15 @@ If you return `true`, `UserProvider` will call the `*_alternative` hooks instead
 - `$userdata`: (WP_User|false) The user object returned by WordPress.
 - `$user_id`: (int) The user ID.
 
+#### Example
+
+```php
+add_filter('slc_filter_get_userdata', function($userdata, $user_id) {
+    // Perform custom processing on the WP_User object
+    return $userdata;
+}, 10, 2);
+```
+
 ### slc_filter_get_userdata_alternative
 Returns user data in alternative mode.
 
@@ -50,7 +65,16 @@ Returns user data in alternative mode.
 
 #### Notes
 
-Return user data that matches the alternative storage or format.
+Return user data that matches the alternative storage or format. It is recommended to return an object that mimics the `WP_User` class. See the [Custom User Object example](#custom-user-object-example) below.
+
+#### Example
+
+```php
+add_filter('slc_filter_get_userdata_alternative', function($user_id) {
+    // Return a custom user object from alternative storage
+    return new MyCustomUser($user_id);
+});
+```
 
 ### slc_filter_get_user_meta
 `UserProvider::get_user_meta()` filters the result of `get_user_meta()` in normal mode.
@@ -61,6 +85,15 @@ Return user data that matches the alternative storage or format.
 - `$user_id`: (int) The user ID.
 - `$key`: (string) The meta key.
 - `$single`: (bool) Whether a single value is requested.
+
+#### Example
+
+```php
+add_filter('slc_filter_get_user_meta', function($meta_value, $user_id, $key, $single) {
+    // Modify the meta value returned from WordPress
+    return $meta_value;
+}, 10, 4);
+```
 
 ### slc_filter_get_user_meta_alternative
 Returns user meta in alternative mode.
@@ -75,6 +108,19 @@ Returns user meta in alternative mode.
 
 Return the meta value retrieved from the alternative storage.
 
+#### Example
+
+```php
+add_filter('slc_filter_get_user_meta_alternative', function($user_id, $key, $single) {
+    // Fetch meta from a custom table
+    global $wpdb;
+    $value = $wpdb->get_var($wpdb->prepare("SELECT meta_value FROM my_custom_table WHERE user_id = %d AND meta_key = %s", $user_id, $key));
+
+    $value = maybe_unserialize($value);
+    return $single ? $value : [$value];
+}, 10, 3);
+```
+
 ### slc_filter_update_user_meta
 `UserProvider::update_user_meta()` filters the result of `update_user_meta()` in normal mode.
 
@@ -85,6 +131,15 @@ Return the meta value retrieved from the alternative storage.
 - `$meta_key`: (string) The meta key.
 - `$meta_value`: (mixed) The new meta value.
 - `$prev_value`: (mixed) The previous meta value.
+
+#### Example
+
+```php
+add_filter('slc_filter_update_user_meta', function($updated, $user_id, $meta_key, $meta_value, $prev_value) {
+    // Perform additional actions when meta is updated
+    return $updated;
+}, 10, 5);
+```
 
 ### slc_filter_update_user_meta_alternative
 Performs a user meta update in alternative mode.
@@ -100,6 +155,21 @@ Performs a user meta update in alternative mode.
 
 Return the result of the alternative implementation.
 
+#### Example
+
+```php
+add_filter('slc_filter_update_user_meta_alternative', function($user_id, $meta_key, $meta_value, $prev_value) {
+    // Update meta in a custom table
+    global $wpdb;
+    $result = $wpdb->update(
+        'my_custom_table',
+        ['meta_value' => maybe_serialize($meta_value)],
+        ['user_id' => $user_id, 'meta_key' => $meta_key]
+    );
+    return $result !== false;
+}, 10, 4);
+```
+
 ### slc_filter_delete_user_meta
 `UserProvider::delete_user_meta()` filters the result of `delete_user_meta()` in normal mode.
 
@@ -109,6 +179,15 @@ Return the result of the alternative implementation.
 - `$user_id`: (int) The user ID.
 - `$meta_key`: (string) The meta key.
 - `$meta_value`: (mixed) The value to delete.
+
+#### Example
+
+```php
+add_filter('slc_filter_delete_user_meta', function($deleted, $user_id, $meta_key, $meta_value) {
+    // Perform additional actions when meta is deleted
+    return $deleted;
+}, 10, 4);
+```
 
 ### slc_filter_delete_user_meta_alternative
 Performs a user meta delete in alternative mode.
@@ -123,12 +202,32 @@ Performs a user meta delete in alternative mode.
 
 Return the delete result from the alternative implementation.
 
+#### Example
+
+```php
+add_filter('slc_filter_delete_user_meta_alternative', function($user_id, $meta_key, $meta_value) {
+    // Delete meta from a custom table
+    global $wpdb;
+    $result = $wpdb->delete('my_custom_table', ['user_id' => $user_id, 'meta_key' => $meta_key]);
+    return $result !== false;
+}, 10, 3);
+```
+
 ### slc_filter_get_current_user_id
 `UserProvider::get_current_user_id()` filters the current user ID in normal mode.
 
 #### Arguments
 
 - `$user_id`: (int) The current user ID.
+
+#### Example
+
+```php
+add_filter('slc_filter_get_current_user_id', function($user_id) {
+    // Override the current user ID logic
+    return $user_id;
+});
+```
 
 ### slc_filter_get_current_user_id_alternative
 Returns the current user ID in alternative mode.
@@ -141,6 +240,15 @@ Returns the current user ID in alternative mode.
 
 Return the ID that should be treated as the current user.
 
+#### Example
+
+```php
+add_filter('slc_filter_get_current_user_id_alternative', function($current_user_id) {
+    // Return current user ID from a custom session or cookie
+    return isset($_SESSION['my_custom_user_id']) ? $_SESSION['my_custom_user_id'] : 0;
+});
+```
+
 ### slc_filter_is_user_id_valid
 Filters the user ID validity check in normal mode.
 
@@ -149,12 +257,31 @@ Filters the user ID validity check in normal mode.
 - `$is_valid`: (bool) Whether the user ID is valid.
 - `$user_id`: (mixed) The user ID being checked.
 
+#### Example
+
+```php
+add_filter('slc_filter_is_user_id_valid', function($is_valid, $user_id) {
+    // Perform custom validation on the user ID
+    return $is_valid;
+}, 10, 2);
+```
+
 ### slc_filter_is_user_id_valid_alternative
 Validates a user ID in alternative mode.
 
 #### Arguments
 
 - `$user_id`: (mixed) The user ID being checked.
+
+#### Example
+
+```php
+add_filter('slc_filter_is_user_id_valid_alternative', function($user_id) {
+    // Check if the user ID exists in the custom table
+    global $wpdb;
+    return (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM my_custom_table WHERE user_id = %d", $user_id)) > 0;
+});
+```
 
 ### slc_filter_get_linked_userids_by_roles_alternative
 Returns linked user IDs for the specified roles in alternative mode.
@@ -166,3 +293,43 @@ Returns linked user IDs for the specified roles in alternative mode.
 #### Notes
 
 Return the array of user IDs linked to LINE for the specified roles.
+
+#### Example
+
+```php
+add_filter('slc_filter_get_linked_userids_by_roles_alternative', function($roles) {
+    // Return custom user IDs that have been linked with LINE and have the specified roles
+    global $wpdb;
+    // Assuming roles are handled via status codes in a custom table
+    return $wpdb->get_col("SELECT user_id FROM my_custom_table WHERE status IN (1, 2) AND has_line_link = 1");
+});
+```
+
+## Custom User Object example
+
+When using alternative mode, `slc_filter_get_userdata_alternative` should return an object that mimics `WP_User`. At a minimum, it should have an `ID` property and a `roles` array.
+
+```php
+class MyCustomUser {
+    public int $ID;
+    public array $roles = [];
+    public string $display_name;
+    public string $user_email;
+
+    public function __construct($user_id) {
+        $this->ID = $user_id;
+        // Load data from custom source
+        $this->display_name = 'Custom User';
+        $this->roles = ['custom_role'];
+    }
+
+    public function exists(): bool {
+        return $this->ID > 0;
+    }
+
+    // Optional: Implement __get to handle other WP_User properties
+    public function __get($name) {
+        return $this->$name ?? null;
+    }
+}
+```

--- a/document/i18n/ja/docusaurus-plugin-content-docs/current/filter/wp-user-alternative/index.md
+++ b/document/i18n/ja/docusaurus-plugin-content-docs/current/filter/wp-user-alternative/index.md
@@ -31,6 +31,12 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 
 `true` を返すと、`UserProvider` は通常の WordPress ユーザー関数の代わりに `*_alternative` フックを呼び出します。
 
+#### 使用例
+
+```php
+add_filter('slc_filter_use_alternative_user_provider', '__return_true');
+```
+
 ## 置き換え用フィルター
 
 ### slc_filter_get_userdata
@@ -41,6 +47,15 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 - `$userdata`: (WP_User|false) WordPress が返したユーザーオブジェクト。
 - `$user_id`: (int) ユーザーID。
 
+#### 使用例
+
+```php
+add_filter('slc_filter_get_userdata', function($userdata, $user_id) {
+    // WP_User オブジェクトに対して独自の処理を行う
+    return $userdata;
+}, 10, 2);
+```
+
 ### slc_filter_get_userdata_alternative
 代替モードでユーザーデータを返します。
 
@@ -50,7 +65,16 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 
 #### 補足
 
-代替の保存先や形式に合わせたユーザーデータを返してください。
+代替の保存先や形式に合わせたユーザーデータを返してください。 `WP_User` クラスを模倣したオブジェクトを返すことを推奨します。詳細は後述の [カスタムユーザーオブジェクトの例](#カスタムユーザーオブジェクトの例) を参照してください。
+
+#### 使用例
+
+```php
+add_filter('slc_filter_get_userdata_alternative', function($user_id) {
+    // 代替ストレージから独自のユーザーオブジェクトを返す
+    return new MyCustomUser($user_id);
+});
+```
 
 ### slc_filter_get_user_meta
 通常モードで `UserProvider::get_user_meta()` が返す `get_user_meta()` の結果を変更します。
@@ -61,6 +85,15 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 - `$user_id`: (int) ユーザーID。
 - `$key`: (string) メタキー。
 - `$single`: (bool) 単一値かどうか。
+
+#### 使用例
+
+```php
+add_filter('slc_filter_get_user_meta', function($meta_value, $user_id, $key, $single) {
+    // WordPress から返されたメタ値を変更する
+    return $meta_value;
+}, 10, 4);
+```
 
 ### slc_filter_get_user_meta_alternative
 代替モードでユーザーメタを返します。
@@ -75,6 +108,19 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 
 代替の保存先から取得したメタ値を返してください。
 
+#### 使用例
+
+```php
+add_filter('slc_filter_get_user_meta_alternative', function($user_id, $key, $single) {
+    // 独自のテーブルからメタ情報を取得する
+    global $wpdb;
+    $value = $wpdb->get_var($wpdb->prepare("SELECT meta_value FROM my_custom_table WHERE user_id = %d AND meta_key = %s", $user_id, $key));
+
+    $value = maybe_unserialize($value);
+    return $single ? $value : [$value];
+}, 10, 3);
+```
+
 ### slc_filter_update_user_meta
 通常モードで `UserProvider::update_user_meta()` が返す `update_user_meta()` の結果を変更します。
 
@@ -85,6 +131,15 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 - `$meta_key`: (string) メタキー。
 - `$meta_value`: (mixed) 新しいメタ値。
 - `$prev_value`: (mixed) 以前のメタ値。
+
+#### 使用例
+
+```php
+add_filter('slc_filter_update_user_meta', function($updated, $user_id, $meta_key, $meta_value, $prev_value) {
+    // メタ情報が更新された際に追加のアクションを実行する
+    return $updated;
+}, 10, 5);
+```
 
 ### slc_filter_update_user_meta_alternative
 代替モードでユーザーメタ更新を実行します。
@@ -100,6 +155,21 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 
 代替実装の更新結果を返してください。
 
+#### 使用例
+
+```php
+add_filter('slc_filter_update_user_meta_alternative', function($user_id, $meta_key, $meta_value, $prev_value) {
+    // 独自のテーブルのメタ情報を更新する
+    global $wpdb;
+    $result = $wpdb->update(
+        'my_custom_table',
+        ['meta_value' => maybe_serialize($meta_value)],
+        ['user_id' => $user_id, 'meta_key' => $meta_key]
+    );
+    return $result !== false;
+}, 10, 4);
+```
+
 ### slc_filter_delete_user_meta
 通常モードで `UserProvider::delete_user_meta()` が返す `delete_user_meta()` の結果を変更します。
 
@@ -109,6 +179,15 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 - `$user_id`: (int) ユーザーID。
 - `$meta_key`: (string) メタキー。
 - `$meta_value`: (mixed) 削除対象のメタ値。
+
+#### 使用例
+
+```php
+add_filter('slc_filter_delete_user_meta', function($deleted, $user_id, $meta_key, $meta_value) {
+    // メタ情報が削除された際に追加のアクションを実行する
+    return $deleted;
+}, 10, 4);
+```
 
 ### slc_filter_delete_user_meta_alternative
 代替モードでユーザーメタ削除を実行します。
@@ -123,12 +202,32 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 
 代替実装の削除結果を返してください。
 
+#### 使用例
+
+```php
+add_filter('slc_filter_delete_user_meta_alternative', function($user_id, $meta_key, $meta_value) {
+    // 独自のテーブルからメタ情報を削除する
+    global $wpdb;
+    $result = $wpdb->delete('my_custom_table', ['user_id' => $user_id, 'meta_key' => $meta_key]);
+    return $result !== false;
+}, 10, 3);
+```
+
 ### slc_filter_get_current_user_id
 通常モードで `UserProvider::get_current_user_id()` が返す現在のユーザーIDを変更します。
 
 #### 引数
 
 - `$user_id`: (int) 現在のユーザーID。
+
+#### 使用例
+
+```php
+add_filter('slc_filter_get_current_user_id', function($user_id) {
+    // 現在のユーザーIDの取得ロジックをオーバーライドする
+    return $user_id;
+});
+```
 
 ### slc_filter_get_current_user_id_alternative
 代替モードで現在のユーザーIDを返します。
@@ -141,6 +240,15 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 
 現在ユーザーとして扱うIDを返してください。
 
+#### 使用例
+
+```php
+add_filter('slc_filter_get_current_user_id_alternative', function($current_user_id) {
+    // 独自のセッションやクッキーから現在のユーザーIDを返す
+    return isset($_SESSION['my_custom_user_id']) ? $_SESSION['my_custom_user_id'] : 0;
+});
+```
+
 ### slc_filter_is_user_id_valid
 通常モードでユーザーIDの妥当性判定を変更します。
 
@@ -149,12 +257,31 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 - `$is_valid`: (bool) ユーザーIDが有効かどうか。
 - `$user_id`: (mixed) 判定対象のユーザーID。
 
+#### 使用例
+
+```php
+add_filter('slc_filter_is_user_id_valid', function($is_valid, $user_id) {
+    // ユーザーIDの妥当性チェックを独自に行う
+    return $is_valid;
+}, 10, 2);
+```
+
 ### slc_filter_is_user_id_valid_alternative
 代替モードでユーザーIDの妥当性を判定します。
 
 #### 引数
 
 - `$user_id`: (mixed) 判定対象のユーザーID。
+
+#### 使用例
+
+```php
+add_filter('slc_filter_is_user_id_valid_alternative', function($user_id) {
+    // 独自のテーブルにユーザーIDが存在するか確認する
+    global $wpdb;
+    return (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM my_custom_table WHERE user_id = %d", $user_id)) > 0;
+});
+```
 
 ### slc_filter_get_linked_userids_by_roles_alternative
 代替モードで指定ロールに紐づくユーザーIDを返します。
@@ -166,3 +293,43 @@ LINE Connect が WordPress のユーザー関連処理を代替実装へ切り�
 #### 補足
 
 指定ロールに対して LINE 連携済みのユーザーID配列を返してください。
+
+#### 使用例
+
+```php
+add_filter('slc_filter_get_linked_userids_by_roles_alternative', function($roles) {
+    // LINE連携済みかつ指定されたロールを持つ、独自のユーザーID一覧を返す
+    global $wpdb;
+    // ロールが独自のテーブルでステータスコードとして管理されていると仮定
+    return $wpdb->get_col("SELECT user_id FROM my_custom_table WHERE status IN (1, 2) AND has_line_link = 1");
+});
+```
+
+## カスタムユーザーオブジェクトの例
+
+代替モードを使用する場合、`slc_filter_get_userdata_alternative` は `WP_User` を模倣したオブジェクトを返す必要があります。最低限、`ID` プロパティと `roles` 配列を持っている必要があります。
+
+```php
+class MyCustomUser {
+    public int $ID;
+    public array $roles = [];
+    public string $display_name;
+    public string $user_email;
+
+    public function __construct($user_id) {
+        $this->ID = $user_id;
+        // 独自ソースからデータを読み込む
+        $this->display_name = 'Custom User';
+        $this->roles = ['custom_role'];
+    }
+
+    public function exists(): bool {
+        return $this->ID > 0;
+    }
+
+    // オプション: 他の WP_User プロパティを扱うために __get を実装
+    public function __get($name) {
+        return $this->$name ?? null;
+    }
+}
+```


### PR DESCRIPTION
This PR adds practical usage examples to the documentation for WP user alternative filters.

Key changes:
- Added `#### Example` / `#### 使用例` sections for all 14 filter hooks.
- Examples are "realistic", showing typical implementation patterns like custom table lookups.
- Documentation was updated in both English (`/docs/filter/wp-user-alternative/index.md`) and Japanese (`/i18n/ja/.../filter/wp-user-alternative/index.md`).
- Added a "Custom User Object" example at the end of the files to guide developers on implementing `WP_User` compatibility.

---
*PR created automatically by Jules for task [17376892155104175191](https://jules.google.com/task/17376892155104175191) started by @shipwebdotjp*